### PR TITLE
fix: disable keep alive for local fetch requests

### DIFF
--- a/src/localFetch.ts
+++ b/src/localFetch.ts
@@ -1,4 +1,5 @@
 import nodeFetch, { RequestInfo, RequestInit } from "node-fetch"
+import * as http from 'http'
 
 import { IFetchComponent } from "@well-known-components/http-server"
 import { IConfigComponent } from "@well-known-components/interfaces"
@@ -31,11 +32,13 @@ export async function createLocalFetchCompoment(
   const protocolHostAndProtocol = `http://${await configComponent.requireString(
     "HTTP_SERVER_HOST"
   )}:${await configComponent.requireNumber("HTTP_SERVER_PORT")}`
+
+  const agent = new http.Agent({ keepAlive: false })
   // test fetch, to hit our local server
   const localFetch: IFetchComponent = {
     async fetch(url: RequestInfo, initRequest?: RequestInit) {
       if (typeof url == "string" && url.startsWith("/")) {
-        return nodeFetch(protocolHostAndProtocol + url, { ...initRequest })
+        return nodeFetch(protocolHostAndProtocol + url, { agent, ...initRequest })
       } else {
         throw new Error("localFetch only works for local testing-URLs")
       }


### PR DESCRIPTION
In node 20 `keepAlive: true` is set for the global HTTP agent[1], but it is very common in our test to start and stop a server in each suite. With the keep alive true the global agent keeps sockets open after the server is down, so with in this version the next suite attempts to reuse the socket, causing an error.

[1] https://github.com/nodejs/node/commit/4267b92604ad78584244488e7f7508a690cb80d0